### PR TITLE
Remove duplicate </body> tag

### DIFF
--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -23,4 +23,4 @@
         import {main} from "/static/main.js";
         main();
     </script>
-</body></body></html>
+</body></html>


### PR DESCRIPTION
Original template had two closing tags for <body>
Modern web browsers ignore closing tags for unopened blocks, but we might as well clean it up while the page is simple enough to notice stuff like this